### PR TITLE
Add EVENT to labeled elements 

### DIFF
--- a/Antescofo.tmLanguage
+++ b/Antescofo.tmLanguage
@@ -46,6 +46,25 @@
 					<key>name</key>
 					<string>constant.language.antescofo</string>
 				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>label.antescofo</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>^\s*(EVENT)\s+(\b.+?\b)\s+(("[^"]*")|(\b[^\s]*\b))</string>
+			<key>name</key>
+			<string>labeled.textslm</string>
+		</dict>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>constant.language.antescofo</string>
+				</dict>
 				<key>4</key>
 				<dict>
 					<key>name</key>


### PR DESCRIPTION
such that it can be shown in Outline package and any other package referencing symbols for quick navigation